### PR TITLE
add external trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: "0 23 * * *"
+  repository_dispatch:
+    types: manual_release
   push:
     branches:
       - master


### PR DESCRIPTION
should allow external trigger for release (using curl) 
```sh
curl -H "Accept: application/vnd.github.everest-preview+json" \
    -H "Authorization: token <your-token-here>" \
    --request POST \
    --data '{"event_type": "manual_release"}' \
    https://api.github.com/repos/SocialGouv/datafiller-data/dispatches
```
[source](https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow)